### PR TITLE
A translated attribute changes on the translated model only when it

### DIFF
--- a/lib/capito/translatable.rb
+++ b/lib/capito/translatable.rb
@@ -125,8 +125,9 @@ module Capito
           getter = attr_name.to_sym
           setter = "#{attr_name}=".to_sym
           define_method(setter) do |value|
-            translation!(Capito.locale).send setter, value
-            attribute_will_change!(getter.to_s)
+            translation = translation!(Capito.locale)
+            translation.send(setter, value)
+            attribute_will_change!(getter.to_s) if translation.changes[getter]
           end
           define_method(getter) { |locale = Capito.locale| translation(locale).send(getter) if translation(locale) }
         end

--- a/test/capito/translatable_test.rb
+++ b/test/capito/translatable_test.rb
@@ -17,6 +17,19 @@ describe Capito::Translatable do
     subject.title.must_equal 'foo'
   end
 
+  it 'does not change when the translation does not change' do
+    subject.title = 'title'
+    subject.save!
+
+    subject.title = 'title'
+    subject.changes[:title].must_be_nil
+  end
+
+  it 'changes when a translation changes' do
+    subject.title = 'newtitle'
+    subject.changes[:title].wont_be_empty
+  end
+
   it 'translated locales are the persisted locales for this translated model' do
     subject.save!
     subject.translations.create(locale: Capito.locale, title: 'my title')


### PR DESCRIPTION
really change in one of its translations.

It prevents unnecessary DB requests.