### PR TITLE
Destroy translated model when deleting its last translation (could be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* `Translatable#destroy_translation` destroys the translation and removes it from the `translations` collection
 * Destroy translated model when deleting its last translation (could be disabled with `translates(destroy_model_without_translation: false`))
 
 ### Capito 0.0.6 (February 25, 2015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Destroy translated model when deleting its last translation (could be disabled with `translates(destroy_model_without_translation: false`))
+
 ### Capito 0.0.6 (February 25, 2015)
 
 * Force translated model attribute change only when the translation really changes

--- a/lib/capito/translatable.rb
+++ b/lib/capito/translatable.rb
@@ -51,7 +51,9 @@ module Capito
     end
 
     def destroy_translation(locale)
-      translation(locale).try(:destroy)
+      if t = translation(locale)
+        translations.destroy(t)
+      end
     end
 
     def save(*args)

--- a/lib/capito/translatable.rb
+++ b/lib/capito/translatable.rb
@@ -62,6 +62,14 @@ module Capito
       end
     end
 
+    def will_destroy
+      @will_destroy = true
+    end
+
+    def will_destroy?
+      @will_destroy
+    end
+
     protected
 
     def build_translation_if_empty
@@ -95,13 +103,20 @@ module Capito
 
       # Accepts a list of attribute names that will be translated.
       # Options:
-      #   * autobuild (boolean) will build a translation before validations if there is no translation built
+      #   * autobuild (boolean, default to true) will build a translation before validations if there is no translation built
+      #   * destroy_model_without_translation (boolean, default to true) will destroy the translated model when deleting its last translation
       def translates(*attr_names, &block)
         options = attr_names.extract_options!
 
         unless options[:autobuild] == false
-          before_validation(:build_translation_if_empty)
+          before_validation :build_translation_if_empty
         end
+
+        unless options[:destroy_model_without_translation] == false
+          before_destroy :will_destroy
+        end
+
+        @translation_class = build_translation_class(options)
 
         if defined? ProtectedAttributes
           attr_accessible :translations, :translations_attributes, *attr_names
@@ -136,7 +151,7 @@ module Capito
       end
 
       def translation_class
-        @translation_class ||= define_translation_class
+        @translation_class
       end
 
       private
@@ -149,17 +164,19 @@ module Capito
         table_name.singularize.foreign_key
       end
 
-      def define_translation_class
+      def build_translation_class(options)
         klass = self.const_get(:Translation) rescue nil
-        if klass.nil?
-          klass = self.const_set(:Translation, Class.new(Capito::Translation))
-        end
+        klass = self.const_set(:Translation, Class.new(Capito::Translation)) if klass.nil?
+
         klass.belongs_to :translated_model, class_name: name, foreign_key: translation_foreign_key, inverse_of: :translations, touch: true
 
         translated_model_alias = self.to_s.demodulize.underscore
         klass.class_eval %Q{ def #{translated_model_alias}; self.translated_model; end }
 
         klass.validates :locale, presence: true, uniqueness: { scope: translation_foreign_key }
+
+        klass.after_destroy :destroy_model_without_translation unless options[:destroy_model_without_translation] == false
+
         klass
       end
     end

--- a/lib/capito/translation.rb
+++ b/lib/capito/translation.rb
@@ -9,5 +9,14 @@ module Capito
     def locale
       read_attribute(:locale).try(:to_sym)
     end
+
+    private
+
+    def destroy_model_without_translation
+      model = translated_model
+      if model && !model.destroyed? && !model.will_destroy? && (model.translations - [self]).empty?
+        model.destroy
+      end
+    end
   end
 end

--- a/test/capito/translatable_test.rb
+++ b/test/capito/translatable_test.rb
@@ -166,6 +166,14 @@ describe Capito::Translatable do
       subject.destroy_translation(:fr)
       subject.translation(:fr).destroyed?.must_equal true
     end
+    it 'destroys the model when it has no other translation' do
+      subject.save!
+      subject.translations.create(locale: :fr, title: 'mon titre')
+      subject.save!
+      subject.translation(:fr).destroyed?.must_equal false
+      subject.destroy_translation(:fr)
+      subject.destroyed?.must_equal true
+    end
   end
 
   describe '#translation' do

--- a/test/capito/translatable_test.rb
+++ b/test/capito/translatable_test.rb
@@ -159,12 +159,21 @@ describe Capito::Translatable do
   describe 'destroy_translation' do
     it 'destroys the translation' do
       subject.save!
-      subject.translations.create(locale: :fr, title: 'mon titre')
+      translation = subject.translations.create(locale: :fr, title: 'mon titre')
       subject.translations.create(locale: :en, title: 'my title')
       subject.save!
       subject.translation(:fr).destroyed?.must_equal false
       subject.destroy_translation(:fr)
-      subject.translation(:fr).destroyed?.must_equal true
+      subject.translation(:fr).must_be_nil
+      assert_raises(ActiveRecord::RecordNotFound) { translation.reload }
+    end
+    it 'keeps non-persisted translations' do
+      subject.save!
+      subject.translations.create(locale: :fr, title: 'mon titre')
+      subject.translations.build(locale: :en, title: 'my title')
+      subject.translation(:fr).destroyed?.must_equal false
+      subject.destroy_translation(:fr)
+      subject.translation(:en).title.must_equal 'my title'
     end
     it 'destroys the model when it has no other translation' do
       subject.save!

--- a/test/capito/translation_class_test.rb
+++ b/test/capito/translation_class_test.rb
@@ -63,4 +63,16 @@ describe 'Capito translation class' do
     subject.locale = :en
     subject.valid?.must_equal false
   end
+
+  it 'destroys the translated model when deleting its last translation' do
+    subject.destroy
+    assert_raises(ActiveRecord::RecordNotFound) { translated_model.reload }
+  end
+
+  it 'does not destroy the translated model with multiple translations when deleting one of its translations' do
+    translated_model.save!
+    translated_model.translations.build(locale: :fr, title: 'English title')
+    subject.destroy
+    translated_model.reload
+  end
 end


### PR DESCRIPTION
disabled with `translates(destroy_model_without_translation: false`))
